### PR TITLE
Update SoapAuthorizationPolicy docs

### DIFF
--- a/user-guide/en-US/All.asciidoc
+++ b/user-guide/en-US/All.asciidoc
@@ -796,7 +796,6 @@ This policy is nearly identical to our Authorization Policy, with the exception 
 Just as with the Authorization policy, you can define any number of rules you'd like.
 
 * *rules* (array) : A single rule that your policy will apply if each of the following properties match:
-** *pathPattern* (string) : Defines the path you'd like the policy to be applicable to.
 ** *action* (string) : Defines the SOAPAction you'd like the policy to be applicable to.
 ** *role* (string) : The role the user must have if this pattern matches the request.
 * *multiMatch* (boolean) : Should the request pass when any or all of the authorization rules pass?  Set to true if all rules must match, false if only one rule must match.
@@ -808,12 +807,10 @@ Just as with the Authorization policy, you can define any number of rules you'd 
 {
    "rules" : [
    	{
-   		"pathPattern": "/admin/.*",
    		"action": "hello",
    		"role": "admin"
    	},
    	{
-   		"pathPattern": "/",
    		"action": "goodbye",
    		"role": "user"
    	}


### PR DESCRIPTION
Summary:
- Removed reference to `pathPattern` for `SoapAuthorizationPolicy` docs.

JIRA: https://issues.jboss.org/browse/APIMAN-1103

Related: https://github.com/apiman/apiman-plugins/pull/63

cc @EricWittmann 