### PR TITLE
fix(installation-guide) Outdated content and invalid URLs for WF8 and EAP64

### DIFF
--- a/developer-guide/en-US/Gateway.asciidoc
+++ b/developer-guide/en-US/Gateway.asciidoc
@@ -51,7 +51,7 @@ final IApiRequestExecutor requestExecutor = engine.executor(request,
 // streamHandler called when back-end connector is ready to receive data.
 requestExecutor.streamHandler(new IAsyncHandler<IApiConnection>() {
   public void handle(final IApiConnection writeStream) { ... }
-}
+});
 
 // Execute the request
 executor.execute();
@@ -78,7 +78,7 @@ requestExecutor.streamHandler(new IAsyncHandler<IApiConnection>() {
     // Call #end only once.
     writeStream.end();
   }
-}
+});
 ```
 
 Any data flowing into the executor must first be wrapped in your implementation of `IApimanBuffer` before being passed to `write`. You may call `write` an unlimited number of times, and indicate that transmission has completed by signalling `end`.
@@ -205,7 +205,7 @@ Looking at an example:
 ```java
 // Native platform's connector (e.g. HTTP)
 ImaginaryBackendConnector imaginaryConnector = ...;
-	Connection c = imaginaryConnector.establishConnection(api.getEndpoint(), ...);
+Connection c = imaginaryConnector.establishConnection(api.getEndpoint(), ...);
 
 // Prepare in advance to do something sensible with the response
 // See next section for more detail.
@@ -298,13 +298,13 @@ void handle(final ImaginaryResponse response) {
       });
 
       // Transmission has finished
-      response.endHandler(new Handler<Void>) {
+      response.endHandler(new Handler<Void>() {
 
         void handle(Void flag) {
           endHandler.handle((Void) null);
           // You may want to close your backend connection here.
         }
-      }
+      });
     }
 
     @Override
@@ -382,4 +382,4 @@ Implementors may notice that the only overlap between the `IApiConnection` and `
 Implementation exemplars:
 
 * link:++https://github.com/apiman/apiman/blob/master/gateway/platforms/servlet/src/main/java/io/apiman/gateway/platforms/servlet/connectors/HttpApiConnection.java++[Servlet HTTP Connector] is a more traditional synchronous implementations.
-* link:++ https://github.com/apiman/apiman/blob/master/gateway/platforms/vertx/src/main/java/io/apiman/gateway/vertx/connector/HttpConnector.java++[Vert.x HTTP Connector] is an asynchronous HTTP implementation.
+* link:++ https://github.com/apiman/apiman/blob/master/gateway/platforms/vertx3/vertx3/src/main/java/io/apiman/gateway/platforms/vertx3/connector/HttpConnector.java++[Vert.x 3 HTTP Connector] is an asynchronous HTTP implementation.

--- a/installation-guide/en-US/Guide.asciidoc
+++ b/installation-guide/en-US/Guide.asciidoc
@@ -5,9 +5,50 @@
 == Installation
 This guide provides detailed information about how to install and configure apiman.
 
+=== Installing in WildFly 10
+The apiman primarily targets WildFly 10 as a runtime environment.  In order to install
+apiman you will need to download both WildFly 10 and the apiman overlay distribution.  Once
+both are downloaded, it's a simple matter of unpacking both into the same location.
+
+==== Download
+First you will need to download both WildFly 10 and apiman:
+
+* http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.zip[Download WildFly 10]
+* http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-wildfly10-1.2.5.Final-overlay.zip[Download apiman 1.2.5.Final]
+
+....
+curl http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.zip -o wildfly-10.0.0.Final.zip
+curl http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-wildfly10-1.2.5.Final-overlay.zip -o apiman-distro-wildfly10-1.2.5.Final-overlay.zip
+....
+
+==== Unpack
+Once both files have been downloaded, simply unpack both in the same location.
+
+....
+unzip wildfly-10.0.0.Final.zip
+unzip -o apiman-distro-wildfly10-1.2.5.Final-overlay.zip -d wildfly-10.0.0.Final
+....
+
+==== Run WildFly 10
+The apiman overlay contains everything needed to run apiman, including:
+
+* apiman binaries (several WAR files)
+* apiman-specific WildFly 10 configuration (*standalone-apiman.xml*)
+* apiman rdbms datasource (h2)
+* pre-configured *admin* user with password *admin123!*
+* pre-configured h2 database for the API Manager (populated with default values)
+* embedded Elasticsearch instance for metrics and gateway storage
+
+For this reason, there is no additional configuration required to run apiman.  Simply start up
+WildFly using the apiman configuration file:
+
+....
+cd wildfly-10.0.0.Final
+./bin/standalone.sh -c standalone-apiman.xml
+....
 
 === Installing in WildFly 9
-The apiman project primarily targets WildFly 9 as a runtime environment.  In order to install
+The apiman project can target WildFly 9 as a runtime environment.  In order to install
 apiman you will need to download both WildFly 9 and the apiman overlay distribution.  Once
 both are downloaded, it's a simple matter of unpacking both into the same location.
 
@@ -48,68 +89,23 @@ cd wildfly-9.0.2.Final
 ./bin/standalone.sh -c standalone-apiman.xml
 ....
 
-
-=== Installing in WildFly 8
-The apiman project primarily targets WildFly 8 as a runtime environment.  In order to install
-apiman you will need to download both WildFly 8 and the apiman overlay distribution.  Once
-both are downloaded, it's a simple matter of unpacking both into the same location.
-
-==== Download
-First you will need to download both WildFly 8 and apiman:
-
-* http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip[Download WildFly 8]
-* http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-wildfly8-1.2.5.Final-overlay.zip[Download apiman 1.2.5.Final]
-
-....
-curl http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip -o wildfly-8.2.0.Final.zip
-curl http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-wildfly8-1.2.5.Final-overlay.zip -o apiman-distro-wildfly8-1.2.5.Final-overlay.zip
-....
-
-==== Unpack
-Once both files have been downloaded, simply unpack both in the same location.
-
-....
-unzip wildfly-8.2.0.Final.zip
-unzip -o apiman-distro-wildfly8-1.2.5.Final-overlay.zip -d wildfly-8.2.0.Final
-....
-
-==== Run WildFly 8
-The apiman overlay contains everything needed to run apiman, including:
-
-* apiman binaries (several WAR files)
-* apiman-specific WildFly 8 configuration (*standalone-apiman.xml*)
-* apiman rdbms datasource (h2)
-* pre-configured *admin* user with password *admin123!*
-* pre-configured h2 database for the API Manager (populated with default values)
-* embedded Elasticsearch instance for metrics and gateway storage
-
-For this reason, there is no additional configuration required to run apiman.  Simply start up
-WildFly using the apiman configuration file:
-
-....
-cd wildfly-8.2.0.Final
-./bin/standalone.sh -c standalone-apiman.xml
-....
-
-
-
-=== Installing in JBoss EAP 6.4
+=== Installing in JBoss EAP 7
 If you prefer to run apiman on a Red Hat supported application server, you can install it
-into JBoss EAP 6.4.  In order to install apiman you will need to download both EAP and the apiman
+into JBoss EAP 7.  In order to install apiman you will need to download both EAP and the apiman
 overlay distribution.  Once both are downloaded, it's a simple matter of unpacking both into the
 same location.
 
 ==== Download
-First you will need to download both EAP 6.4 and apiman:
+First you will need to download both EAP 7 and apiman:
 
-* http://www.jboss.org/products/eap/download/[Download EAP 6.4]
-* http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-eap64-1.2.5.Final-overlay.zip[Download apiman 1.2.5.Final]
+* http://www.jboss.org/products/eap/download/[Download EAP 7]
+* http://downloads.jboss.org/apiman/1.2.5.Final/apiman-distro-eap7-1.2.5.Final-overlay.zip[Download apiman 1.2.5.Final]
 
 ==== Unpack
 Once both files have been downloaded, simply unpack both in the same location (see the instructions
 for Wildfly above).
 
-==== Run EAP 6.4
+==== Run EAP 7
 The apiman overlay contains everything needed to run apiman, including:
 
 * apiman binaries (several WAR files)


### PR DESCRIPTION
Also, fix another broken link (Vert.x connector) and some minor syntax issues that were making my Atom's asciidoc highlighter overflow the code block.